### PR TITLE
Hack: install.sh detects aibook

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -248,11 +248,10 @@ check_gpu() {
             esac ;;
         dmidecode)
             case $2 in
-                mtgpu)  available dmidecode && $SUDO dmidecode | grep -q 'AB100' || return 1 ;;
+                mtgpu)  available dmidecode && $SUDO dmidecode | grep -iE 'AB100|M1000' || return 1 ;;
             esac ;;
-        nvidia-smi)   available nvidia-smi || return 1 ;;
-        mthreads-gmi) available mthreads-gmi || return 1 ;;
-        mthreads-smi) available mthreads-smi || return 1 ;;
+        nvidia-smi) available nvidia-smi || return 1 ;;
+        mthreads-*) available $1 || return 1 ;;
     esac
 }
 


### PR DESCRIPTION
```bash
mt@mt-Not-Specified:~$ sudo dmidecode | grep -iE 'AB100|M1000'
        Version: AB100
```

## Summary by Sourcery

Enhance GPU detection in install.sh by adding dmidecode-based checks for AIBook (AB100/M1000) platforms and broadening MTHREADS command support.

Enhancements:
- Add dmidecode probe for identifying MTHREADS GPU devices by matching AB100 or M1000.
- Include mthreads-smi alongside mthreads-gmi in the GPU installation check.
- Generalize the MTHREADS detection pattern from mthreads-gmi to any mthreads-*.
- Incorporate the dmidecode mtgpu check into the fallback GPU detection logic before defaulting to CPU-only mode.