### PR TITLE
Enable FlashAttentionSupported

### DIFF
--- a/discover/types.go
+++ b/discover/types.go
@@ -182,7 +182,8 @@ func (l GpuInfoList) FlashAttentionSupported() bool {
 	for _, gpu := range l {
 		supportsFA := gpu.Library == "metal" ||
 			(gpu.Library == "cuda" && gpu.DriverMajor >= 7) ||
-			gpu.Library == "rocm"
+			gpu.Library == "rocm" ||
+			gpu.Library == "musa"
 
 		if !supportsFA {
 			return false


### PR DESCRIPTION
### Testing Done

* [x] Build completed successfully
* [x] `flash_attn` can be enabled using `export OLLAMA_FLASH_ATTENTION=1`

  ```log
  llama_context: flash_attn    = 1
  ```

## Summary by Sourcery

Enhancements:
- Include 'musa' as a recognized library in the FlashAttentionSupported GPU backends