### PR TITLE
Hack: update version for building docker image and tgz

### DIFF
--- a/scripts/build_linux_musa.sh
+++ b/scripts/build_linux_musa.sh
@@ -20,7 +20,7 @@ echo "TARGET: $TARGET"
 echo "Platform: $OS/$ARCH"
 
 # Set up environment variables (similar to setup-environment job)
-VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
+VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --always | sed -e "s/^v//g")}
 GOFLAGS="'-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$VERSION\" \"-X=github.com/ollama/ollama/server.mode=release\"'"
 
 echo "VERSION: $VERSION"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,6 @@
 # Common environment setup across build*.sh scripts
 
-export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
+export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --always | sed -e "s/^v//g")}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$VERSION\" \"-X=github.com/ollama/ollama/server.mode=release\"'"
 # TODO - consider `docker buildx ls --format=json` to autodiscover platform capability
 PLATFORM=${PLATFORM:-"linux/arm64,linux/amd64"}


### PR DESCRIPTION
### Testing Done

```bash
❯ git describe --tags --first-parent --abbrev=7 --always | sed -e "s/^v//g"
0.9.3
```

## Summary by Sourcery

Simplify version detection in build scripts by adjusting git describe options to remove unnecessary flags

Build:
- Simplify version extraction in build_linux_musa.sh by removing --long and --dirty flags from git describe
- Simplify version extraction in env.sh by removing --long and --dirty flags from git describe