### PR TITLE
musa: support new SDK rc4.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(MUSAToolkit_FOUND)
         install(TARGETS ggml-musa
             RUNTIME_DEPENDENCIES
                 DIRECTORIES ${MUSAToolkit_BIN_DIR} ${MUSAToolkit_LIBRARY_DIR}
-                PRE_INCLUDE_REGEXES mublas musart musa
+                PRE_INCLUDE_REGEXES mublas musart
                 PRE_EXCLUDE_REGEXES ".*"
             RUNTIME DESTINATION ${OLLAMA_MUSA_INSTALL_DIR} COMPONENT MUSA
             LIBRARY DESTINATION ${OLLAMA_MUSA_INSTALL_DIR} COMPONENT MUSA

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROCMVERSION=6.3.3
 ARG JETPACK5VERSION=r35.4.1
 ARG JETPACK6VERSION=r36.4.0
 ARG CMAKEVERSION=3.31.2
-ARG MUSAVERSION=20250826
+ARG MUSAVERSION=rc4.3.0
 ARG UBUNTUVERSION=22.04
 ARG VULKANVERSION=1.4.321.1
 
@@ -150,7 +150,7 @@ RUN --mount=type=cache,target=/root/.ccache \
         && cmake --install build --component VULKAN --strip --parallel 8
 
 # Moore Threads (MUSA) build stages
-FROM sh-harbor.mthreads.com/haive/mthreads/musa:${MUSAVERSION}-devel-ubuntu${UBUNTUVERSION}-amd64 AS musa-4
+FROM mthreads/musa:${MUSAVERSION}-devel-ubuntu${UBUNTUVERSION}-amd64 AS musa-4
 RUN apt-get update \
     && apt-get install -y curl \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROCMVERSION=6.3.3
 ARG JETPACK5VERSION=r35.4.1
 ARG JETPACK6VERSION=r36.4.0
 ARG CMAKEVERSION=3.31.2
-ARG MUSAVERSION=rc4.2.0
+ARG MUSAVERSION=20250826
 ARG UBUNTUVERSION=22.04
 ARG VULKANVERSION=1.4.321.1
 
@@ -150,7 +150,7 @@ RUN --mount=type=cache,target=/root/.ccache \
         && cmake --install build --component VULKAN --strip --parallel 8
 
 # Moore Threads (MUSA) build stages
-FROM mthreads/musa:${MUSAVERSION}-devel-ubuntu${UBUNTUVERSION}-amd64 AS musa-4
+FROM sh-harbor.mthreads.com/haive/mthreads/musa:${MUSAVERSION}-devel-ubuntu${UBUNTUVERSION}-amd64 AS musa-4
 RUN apt-get update \
     && apt-get install -y curl \
     && apt-get clean \
@@ -164,14 +164,6 @@ RUN --mount=type=cache,target=/root/.ccache \
     cmake --preset 'MUSA 4' \
         && cmake --build --parallel --preset 'MUSA 4' \
         && cmake --install build --component MUSA --strip --parallel 8
-# TODO: Remove the following lines in next release
-RUN cd dist/lib/ollama/musa_v4 && \
-    for f in libmusa.so.*; do \
-        if [ -f "$f" ] && [[ "$f" =~ ^libmusa\.so\.[0-9]+$ ]]; then \
-            ln -sf "$f" libmusa.so; \
-            break; \
-        fi; \
-    done
 
 FROM scratch AS musa
 COPY --from=musa-4 dist/lib/ollama/musa_v4 /lib/ollama/musa_v4

--- a/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
@@ -78,6 +78,8 @@
 #define GGML_CUDA_CC_IS_CDNA3(cc) (cc >= GGML_CUDA_CC_CDNA3 && cc < GGML_CUDA_CC_RDNA1)
 
 // Moore Threads
+#define MUSART_HMASK 40300 // MUSA rc4.3, min. ver. for half2 -> uint mask comparisons
+
 #define GGML_CUDA_CC_QY1 (GGML_CUDA_CC_OFFSET_MTHREADS + 0x210) // MTT S80, MTT S3000
 #define GGML_CUDA_CC_QY2 (GGML_CUDA_CC_OFFSET_MTHREADS + 0x220) // MTT S4000
 #define GGML_CUDA_CC_NG  (GGML_CUDA_CC_OFFSET_MTHREADS + 0x310) // TBD
@@ -510,13 +512,14 @@ static __device__ __forceinline__ half2 warp_reduce_max(half2 x) {
 #endif // !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= GGML_CUDA_CC_PASCAL || (defined(GGML_USE_HIP) && HIP_VERSION >= 50700000)
 }
 
-#if CUDART_VERSION < CUDART_HMASK
+#if (defined(CUDART_VERSION) && CUDART_VERSION < CUDART_HMASK) || defined(GGML_USE_HIP) || \
+    (defined(MUSART_VERSION) && MUSART_VERSION < MUSART_HMASK)
 static __device__ __forceinline__ uint32_t __hgt2_mask(const half2 a, const half2 b) {
     const uint32_t mask_low  = 0x0000FFFF * (float( __low2half(a)) > float( __low2half(b)));
     const uint32_t mask_high = 0xFFFF0000 * (float(__high2half(a)) > float(__high2half(b)));
     return mask_low | mask_high;
 }
-#endif // CUDART_VERSION < CUDART_HMASK
+#endif // (defined(CUDART_VERSION) && CUDART_VERSION < CUDART_HMASK) || defined(GGML_USE_HIP) || (defined(MUSART_VERSION) && MUSART_VERSION < MUSART_HMASK)
 
 static __device__ __forceinline__ int ggml_cuda_dp4a(const int a, const int b, int c) {
 #if defined(GGML_USE_HIP)

--- a/ml/backend/ggml/ggml/src/ggml-musa/CMakeLists.txt
+++ b/ml/backend/ggml/ggml/src/ggml-musa/CMakeLists.txt
@@ -56,7 +56,7 @@ if (MUSAToolkit_FOUND)
 
     set_source_files_properties(${GGML_SOURCES_MUSA} PROPERTIES LANGUAGE CXX)
     foreach(SOURCE ${GGML_SOURCES_MUSA})
-        set(COMPILE_FLAGS "-fsigned-char -x musa -mtgpu")
+        set(COMPILE_FLAGS "-Od3 -fno-strict-aliasing -ffast-math -fsigned-char -x musa -mtgpu -fmusa-flush-denormals-to-zero")
         foreach(ARCH ${MUSA_ARCHITECTURES})
             set(COMPILE_FLAGS "${COMPILE_FLAGS} --cuda-gpu-arch=mp_${ARCH}")
         endforeach()

--- a/scripts/push_docker_mthreads.sh
+++ b/scripts/push_docker_mthreads.sh
@@ -10,7 +10,7 @@ for FLAVOR in $FLAVORS; do
     case "$FLAVOR" in
         musa)
             if [ "$PLATFORM" = "linux/amd64" ]; then
-                MUSAVERSION="rc4.2.0"
+                MUSAVERSION="rc4.3.0"
                 BASE_TAG="${MANIFEST_TAG}-${ARCH}"
                 VERSIONED_TAG="${MANIFEST_TAG}-${MUSAVERSION}-${ARCH}"
                 LATEST_TAG="${FINAL_IMAGE_REPO}:latest"


### PR DESCRIPTION
1. Remove `libmusa.so` from packaging
2. Manually merge https://github.com/ggml-org/llama.cpp/pull/15413
3. Update compile flags (see: https://github.com/ggml-org/llama.cpp/pull/16265)